### PR TITLE
Release v1.2.4 | Constructor overrides, concurrency safety and ready for v1.2.4 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## [1.2.4] - 6th Feb, 2024
 
+- **MINOR BREAKING:** Removed getter and setter for `profile` in `OpenRouteService` class. It is now final and can only be set via the constructor `defaultProfile` parameter. This system is more concurrency-safe. If it needs to be overridden at the API call level, that can anyway be done by passing in `profileOverride` to the respective API method.
+
 - Made API more flexible by allowing constructor-based overrides in `OpenRouteService` class of:
   - `baseUrl`, the default API Base URL
   - `client`, the HTTP Client being used to make the requests
   - `defaultProfile`, the default profile being used to make the requests.
-
-- **MINOR BREAKING**: Removed getter and setter for `profile` in `OpenRouteService` class. It is now final and can only be set via the constructor `defaultProfile` parameter. This system is more concurrency-safe. If it needs to be overriden at API call level, that can any way be done by passing in `profileOverride` to the respective API method.
 
 - Ternary operator null check replaced with null-aware operator in Vroom and Optimization data models.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Releases
 
+## [1.2.4] - 6th Feb, 2024
+
+- Made API more flexible by allowing constructor-based overrides in `OpenRouteService` class of:
+  - `baseUrl`, the default API Base URL
+  - `client`, the HTTP Client being used to make the requests
+  - `defaultProfile`, the default profile being used to make the requests.
+- MINOR BREAKING CHANGE: Removed getter and setter for `profile` in `OpenRouteService` class. It is now final and can only be set via the constructor `defaultProfile` parameter.
+  - This system is more concurrency-safe. If it needs to be overriden at API call level, that can any way be done by passing in `profileOverride` to the respective API method.
+
 ## [1.2.3] - 24th June, 2023
 
 - Upgraded dependencies to keep up with the latest versions of the packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Ternary operator null check replaced with null-aware operator in Vroom and Optimization data models.
 
+- Getting `ORSProfile` from `String` name and vice versa is now done using a map internally, making it more readable and maintainable.
+
 ## [1.2.3] - 24th June, 2023
 
 - Upgraded dependencies to keep up with the latest versions of the packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
   - `baseUrl`, the default API Base URL
   - `client`, the HTTP Client being used to make the requests
   - `defaultProfile`, the default profile being used to make the requests.
-- MINOR BREAKING CHANGE: Removed getter and setter for `profile` in `OpenRouteService` class. It is now final and can only be set via the constructor `defaultProfile` parameter.
-  - This system is more concurrency-safe. If it needs to be overriden at API call level, that can any way be done by passing in `profileOverride` to the respective API method.
+
+- **MINOR BREAKING**: Removed getter and setter for `profile` in `OpenRouteService` class. It is now final and can only be set via the constructor `defaultProfile` parameter. This system is more concurrency-safe. If it needs to be overriden at API call level, that can any way be done by passing in `profileOverride` to the respective API method.
+
+- Ternary operator null check replaced with null-aware operator in Vroom and Optimization data models.
 
 ## [1.2.3] - 24th June, 2023
 
@@ -20,8 +22,10 @@
 ## [1.2.1] - 10th February, 2022
 
 - Better Response Status-Code verification logic as for posts it won't always be 200.
+
 - **BREAKING:** Separated and refined openrouteservice path-profile String and ORSProfile interconversion logic.
   `OpenRouteService.getProfileString(ORSProfile profile)` -> `profile.name`
+
 - **Minor:** Dev Dependencies updated. Pubspec improved.
 
 ## [1.1.1] - 06th February, 2022
@@ -32,20 +36,27 @@
 
 - **BREAKING:** Renamed `OpenRouteService` methods with even stricter naming convention:
     ```{API endpoint name} + {functionality name} + Post / Get (Based on type of Request)```
+
 - **BREAKING:** `Coordinate` Model renamed to `ORSCoordinate` to avoid ambiguity with other location based packages.
+
 - `ORSCoordinate.fromJSON()` fixes for errors with altitude: potential null error and wrong key fixed.
 
 ## [1.0.1] - 31st October, 2021
 
 - Restriction applied to `request` parameter of `ORSPois.poisDataPostGet` with `ArgumentError` if restriction not followed, as per API convention. `request` can now only be 'pois', 'stats' or 'list' as per openrouteservice API.
+
 - Linted Code. :)
 
 ## [1.0.0] - 30th October, 2021
 
 - First Stable Release (unless there is some breaking bug that slipped by).
+
 - Addition of GeoCoding API.
+
 - Metadata models.
+
 - **BREAKING:** GeoJsonFeatureProperties Data Model removed and replaced with unparsed `Map<String, dynamic>` as it doesn't have any static structure across various endpoints.
+
 - **BREAKING:** Every method in the package has been renamed for consistency and to easily find needed methods. New method naming convention:
 
   ```{API endpoint name} + {functionality name} + (if functionality uses a POST endpoint) Post + Get```
@@ -55,32 +66,42 @@
 ## [0.7.0] - 27th September, 2021
 
 - **BREAKING:** `Matrix*` -> `TimeDistanceMatrix*`
+
 - Adjust cgiar attribution link from http to https
+
 - `Coordinate` model `toList` and `fromList` methods added for convenience (with null safety).
+
 - Documentation updates.
+
 - Encapsulated `Optimization` API.
 
 ## [0.6.0] - 26th September, 2021
 
 - **BREAKING:** Naming conventions changed: `OpenRouteService*` -> `ORS*`.
+
 - Encapsulated `Matrix` API.
+
 - Encapsulated `POIs` API.
 
 ## [0.5.2] - 26th September, 2021
 
 - Reworked the entire `Directions` API system to enable usage of both the normal POST endpoint as `getMultiRouteDirectionsData` and the geojson POST endpoint `getMultiRouteDirectionsGeoJson`.
+
 - Common `GeoJsonFeatureCollection` Data Model created to be used with both the `Directions` API and the `Isochrones` API, whenever geojson is involved.
 
 ## [0.5.1] - 26th September, 2021
 
 - Dart SDK version change to pass static analysis on pub.dev.
+
 - Ran `dart format` on all Dart files to be in compliance with Dart's style guide.
 
 ## [0.5.0] - 26th September, 2021
 
 - Initial version.
+
 - APIs of OpenRouteService currently encapsulated and available:
   1. [Directions](https://openrouteservice.org/dev/#/api-docs/v2/directions/)
   2. [Elevation](https://openrouteservice.org/dev/#/api-docs/elevation/)
   3. [Isochrones](https://openrouteservice.org/dev/#/api-docs/v2/isochrones/)
+
 - Tests Ready for the APIs too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Made API more flexible by allowing constructor-based overrides in `OpenRouteService` class of:
   - `baseUrl`, the default API Base URL
   - `client`, the HTTP Client being used to make the requests
-  - `defaultProfile`, the default profile being used to make the requests.
+  - `defaultProfile`, the default openrouteservice route profile being used to make the requests.
 
 - Ternary operator null check replaced with null-aware operator in Vroom and Optimization data models.
 

--- a/lib/src/models/optimization_models/optimization_data_models.dart
+++ b/lib/src/models/optimization_models/optimization_data_models.dart
@@ -266,12 +266,9 @@ class OptimizationRoute {
         'service': service,
         'duration': duration,
         'waiting_time': waitingTime,
-        'steps': steps == null
-            ? null
-            : steps!
-                .map<Map<String, dynamic>>(
-                    (OptimizationRouteStep e) => e.toJson())
-                .toList(),
+        'steps': steps
+            ?.map<Map<String, dynamic>>((OptimizationRouteStep e) => e.toJson())
+            .toList(),
       }..removeWhere((String _, dynamic value) => value == null);
 
   @override

--- a/lib/src/models/optimization_models/vroom_data_models.dart
+++ b/lib/src/models/optimization_models/vroom_data_models.dart
@@ -143,19 +143,16 @@ class VroomVehicle {
         'capacity': capacity,
         'skills': skills,
         'time_window': timeWindow,
-        'breaks': breaks == null
-            ? null
-            : breaks!
-                .map<Map<String, dynamic>>((VroomVehicleBreak b) => b.toJson())
-                .toList(),
+        'breaks': breaks
+            ?.map<Map<String, dynamic>>((VroomVehicleBreak b) => b.toJson())
+            .toList(),
         'speed_factor': speedFactor,
         'max_tasks': maxTasks,
-        'steps': steps == null
-            ? null
-            : steps!
-                .map<Map<String, dynamic>>(
-                    (VroomVehicleStep step) => step.toJson())
-                .toList(),
+        'steps': steps
+            ?.map<Map<String, dynamic>>(
+              (VroomVehicleStep step) => step.toJson(),
+            )
+            .toList(),
       }..removeWhere((String _, dynamic value) => value == null);
 
   @override

--- a/lib/src/models/ors_profile_enum.dart
+++ b/lib/src/models/ors_profile_enum.dart
@@ -21,39 +21,37 @@ enum ORSProfile {
 /// - Provide a [String] representation of the profile
 /// - Statically get [ORSProfile]s from [String]s.
 extension ORSProfileNamer on ORSProfile {
+  static Map<ORSProfile, String> get _profileToNameMap => <ORSProfile, String>{
+        ORSProfile.drivingCar: 'driving-car',
+        ORSProfile.drivingHgv: 'driving-hgv',
+        ORSProfile.cyclingRoad: 'cycling-road',
+        ORSProfile.cyclingMountain: 'cycling-mountain',
+        ORSProfile.cyclingElectric: 'cycling-electric',
+        ORSProfile.footWalking: 'foot-walking',
+        ORSProfile.footHiking: 'foot-hiking',
+        ORSProfile.wheelchair: 'wheelchair',
+      };
+
+  static Map<String, ORSProfile> get _nameToProfileMap => <String, ORSProfile>{
+        'driving-car': ORSProfile.drivingCar,
+        'driving-hgv': ORSProfile.drivingHgv,
+        'cycling-road': ORSProfile.cyclingRoad,
+        'cycling-mountain': ORSProfile.cyclingMountain,
+        'cycling-electric': ORSProfile.cyclingElectric,
+        'foot-walking': ORSProfile.footWalking,
+        'foot-hiking': ORSProfile.footHiking,
+        'wheelchair': ORSProfile.wheelchair,
+      };
+
   /// Returns the [String] representation of the openrouteservice profile
   /// represented by the enum.
   ///
   /// Throws [ArgumentError] if the enum is not a valid profile.
   String get name {
-    switch (this) {
-      case ORSProfile.drivingCar:
-        return 'driving-car';
-
-      case ORSProfile.drivingHgv:
-        return 'driving-hgv';
-
-      case ORSProfile.cyclingRoad:
-        return 'cycling-road';
-
-      case ORSProfile.cyclingMountain:
-        return 'cycling-mountain';
-
-      case ORSProfile.cyclingElectric:
-        return 'cycling-electric';
-
-      case ORSProfile.footWalking:
-        return 'foot-walking';
-
-      case ORSProfile.footHiking:
-        return 'foot-hiking';
-
-      case ORSProfile.wheelchair:
-        return 'wheelchair';
-
-      default:
-        throw ArgumentError('Unknown ORSProfile: $this');
+    if (_profileToNameMap.containsKey(this)) {
+      return _profileToNameMap[this]!;
     }
+    throw ArgumentError('Unknown ORSProfile: $this');
   }
 
   /// Returns the [ORSProfile] represented by the [String] profileName.
@@ -64,33 +62,9 @@ extension ORSProfileNamer on ORSProfile {
   ///
   /// If the [String] is not one of the above, an [ArgumentError] is thrown.
   static ORSProfile fromName(final String profileName) {
-    switch (profileName) {
-      case 'driving-car':
-        return ORSProfile.drivingCar;
-
-      case 'driving-hgv':
-        return ORSProfile.drivingHgv;
-
-      case 'cycling-road':
-        return ORSProfile.cyclingRoad;
-
-      case 'cycling-mountain':
-        return ORSProfile.cyclingMountain;
-
-      case 'cycling-electric':
-        return ORSProfile.cyclingElectric;
-
-      case 'foot-walking':
-        return ORSProfile.footWalking;
-
-      case 'foot-hiking':
-        return ORSProfile.footHiking;
-
-      case 'wheelchair':
-        return ORSProfile.wheelchair;
-
-      default:
-        throw ArgumentError('Unknown ORSProfile: $profileName');
+    if (_nameToProfileMap.containsKey(profileName)) {
+      return _nameToProfileMap[profileName]!;
     }
+    throw ArgumentError('Unknown ORSProfile: $profileName');
   }
 }

--- a/lib/src/models/ors_profile_enum.dart
+++ b/lib/src/models/ors_profile_enum.dart
@@ -21,27 +21,27 @@ enum ORSProfile {
 /// - Provide a [String] representation of the profile
 /// - Statically get [ORSProfile]s from [String]s.
 extension ORSProfileNamer on ORSProfile {
-  static Map<ORSProfile, String> get _profileToNameMap => <ORSProfile, String>{
-        ORSProfile.drivingCar: 'driving-car',
-        ORSProfile.drivingHgv: 'driving-hgv',
-        ORSProfile.cyclingRoad: 'cycling-road',
-        ORSProfile.cyclingMountain: 'cycling-mountain',
-        ORSProfile.cyclingElectric: 'cycling-electric',
-        ORSProfile.footWalking: 'foot-walking',
-        ORSProfile.footHiking: 'foot-hiking',
-        ORSProfile.wheelchair: 'wheelchair',
-      };
+  static const Map<ORSProfile, String> _profileToNameMap = <ORSProfile, String>{
+    ORSProfile.drivingCar: 'driving-car',
+    ORSProfile.drivingHgv: 'driving-hgv',
+    ORSProfile.cyclingRoad: 'cycling-road',
+    ORSProfile.cyclingMountain: 'cycling-mountain',
+    ORSProfile.cyclingElectric: 'cycling-electric',
+    ORSProfile.footWalking: 'foot-walking',
+    ORSProfile.footHiking: 'foot-hiking',
+    ORSProfile.wheelchair: 'wheelchair',
+  };
 
-  static Map<String, ORSProfile> get _nameToProfileMap => <String, ORSProfile>{
-        'driving-car': ORSProfile.drivingCar,
-        'driving-hgv': ORSProfile.drivingHgv,
-        'cycling-road': ORSProfile.cyclingRoad,
-        'cycling-mountain': ORSProfile.cyclingMountain,
-        'cycling-electric': ORSProfile.cyclingElectric,
-        'foot-walking': ORSProfile.footWalking,
-        'foot-hiking': ORSProfile.footHiking,
-        'wheelchair': ORSProfile.wheelchair,
-      };
+  static const Map<String, ORSProfile> _nameToProfileMap = <String, ORSProfile>{
+    'driving-car': ORSProfile.drivingCar,
+    'driving-hgv': ORSProfile.drivingHgv,
+    'cycling-road': ORSProfile.cyclingRoad,
+    'cycling-mountain': ORSProfile.cyclingMountain,
+    'cycling-electric': ORSProfile.cyclingElectric,
+    'foot-walking': ORSProfile.footWalking,
+    'foot-hiking': ORSProfile.footHiking,
+    'wheelchair': ORSProfile.wheelchair,
+  };
 
   /// Returns the [String] representation of the openrouteservice profile
   /// represented by the enum.

--- a/lib/src/open_route_service_base.dart
+++ b/lib/src/open_route_service_base.dart
@@ -41,30 +41,31 @@ part 'package:open_route_service/src/services/pois.dart';
 class OpenRouteService {
   OpenRouteService({
     required String apiKey,
-    ORSProfile profile = ORSProfile.footWalking,
+    String baseUrl = OpenRouteService.defaultBaseUrl,
+    http.Client? client,
+    ORSProfile defaultProfile = ORSProfile.footWalking,
   })  : _apiKey = apiKey,
-        _profile = profile {
-    // Initialize HTTP client
-    _client = http.Client();
+        _baseUrl = baseUrl,
+        _defaultProfile = defaultProfile {
+    // Initialize HTTP client if not provided.
+    _client = client ?? http.Client();
   }
 
   /// The API key used to authenticate the request.
   final String _apiKey;
 
+  /// The base URL of all the endpoints.
+  /// Defaults to [defaultBaseUrl].
+  final String _baseUrl;
+
   /// HTTP Client used to persistently make the request.
   late final http.Client _client;
 
   /// The path parameter determines the routing method.
-  ORSProfile _profile;
+  final ORSProfile _defaultProfile;
 
-  /// The base URL of all the endpoints, https://api.openrouteservice.org
-  static const String _baseURL = 'https://api.openrouteservice.org';
-
-  /// Get current profile/path parameter.
-  ORSProfile get profile => _profile;
-
-  /// Change the profile/path parameter.
-  set setProfile(ORSProfile newPathParam) => _profile = newPathParam;
+  /// The default base URL of all the endpoints, https://api.openrouteservice.org
+  static const String defaultBaseUrl = 'https://api.openrouteservice.org';
 
   /// Performs a GET request on the OpenRouteService API endpoint [uri].
   ///

--- a/lib/src/services/directions.dart
+++ b/lib/src/services/directions.dart
@@ -2,8 +2,7 @@ part of 'package:open_route_service/src/open_route_service_base.dart';
 
 extension ORSDirections on OpenRouteService {
   /// The endpoint of the openrouteservice Directions API.
-  static const String _directionsEndpointURL =
-      '${OpenRouteService._baseURL}/v2/directions';
+  String get _directionsEndpointURL => '$_baseUrl/v2/directions';
 
   /// Fetches the Direction Route information for the route between
   /// [startCoordinate] and [endCoordinate] from the openrouteservice API,
@@ -20,7 +19,7 @@ extension ORSDirections on OpenRouteService {
     ORSProfile? profileOverride,
   }) async {
     // If a path parameter override is provided, use it.
-    final ORSProfile chosenPathParam = profileOverride ?? _profile;
+    final ORSProfile chosenPathParam = profileOverride ?? _defaultProfile;
 
     // Extract coordinate information.
     final double startLat = startCoordinate.latitude;
@@ -96,7 +95,7 @@ extension ORSDirections on OpenRouteService {
     ORSProfile? profileOverride,
   }) async {
     // If a path parameter override is provided, use it.
-    final ORSProfile chosenPathParam = profileOverride ?? _profile;
+    final ORSProfile chosenPathParam = profileOverride ?? _defaultProfile;
 
     // Build the request URL.
     final Uri uri =
@@ -237,7 +236,7 @@ extension ORSDirections on OpenRouteService {
     ORSProfile? profileOverride,
   }) async {
     // If a path parameter override is provided, use it.
-    final ORSProfile chosenPathParam = profileOverride ?? _profile;
+    final ORSProfile chosenPathParam = profileOverride ?? _defaultProfile;
 
     // Build the request URL.
     final Uri uri =

--- a/lib/src/services/elevation.dart
+++ b/lib/src/services/elevation.dart
@@ -2,8 +2,7 @@ part of 'package:open_route_service/src/open_route_service_base.dart';
 
 extension ORSElevation on OpenRouteService {
   /// The endpoint of the openrouteservice Elevation API.
-  static const String _elevationEndpointURL =
-      '${OpenRouteService._baseURL}/elevation';
+  String get _elevationEndpointURL => '$_baseUrl/elevation';
 
   /// Fetches the [ElevationData] by taking a 2D [geometry] and enriching it
   /// with  elevation from a variety of datasets. Uses the GET method for the

--- a/lib/src/services/geocode.dart
+++ b/lib/src/services/geocode.dart
@@ -2,8 +2,7 @@ part of 'package:open_route_service/src/open_route_service_base.dart';
 
 extension ORSGeocode on OpenRouteService {
   /// The endpoint of the openrouteservice Geocode API.
-  static const String _geocodeEndpointURL =
-      '${OpenRouteService._baseURL}/geocode';
+  String get _geocodeEndpointURL => '$_baseUrl/geocode';
 
   /// Available Sources for Geocoding
   Set<String> get geocodeSourcesAvailable =>

--- a/lib/src/services/isochrones.dart
+++ b/lib/src/services/isochrones.dart
@@ -1,8 +1,7 @@
 part of 'package:open_route_service/src/open_route_service_base.dart';
 
 extension ORServiceIsochrones on OpenRouteService {
-  static const String _isochronesEndpointURL =
-      '${OpenRouteService._baseURL}/v2/isochrones';
+  String get _isochronesEndpointURL => '$_baseUrl/v2/isochrones';
 
   /// Obtain Isochrone (areas of reachability) Data for the [locations] given
   /// as a [List] of [ORSCoordinate].
@@ -34,7 +33,7 @@ extension ORServiceIsochrones on OpenRouteService {
     ORSProfile? profileOverride,
   }) async {
     // If a path parameter override is provided, use it.
-    final ORSProfile chosenPathParam = profileOverride ?? _profile;
+    final ORSProfile chosenPathParam = profileOverride ?? _defaultProfile;
 
     // Build the request URL.
     final Uri uri =

--- a/lib/src/services/matrix.dart
+++ b/lib/src/services/matrix.dart
@@ -2,8 +2,7 @@ part of 'package:open_route_service/src/open_route_service_base.dart';
 
 extension ORSMatrix on OpenRouteService {
   /// The endpoint of the openrouteservice Matrix API.
-  static const String _matrixEndpointURL =
-      '${OpenRouteService._baseURL}/v2/matrix';
+  String get _matrixEndpointURL => '$_baseUrl/v2/matrix';
 
   /// Returns duration, distance matrix for multiple source, destination points.
   ///
@@ -28,7 +27,7 @@ extension ORSMatrix on OpenRouteService {
     ORSProfile? profileOverride,
   }) async {
     // If a path parameter override is provided, use it.
-    final ORSProfile chosenPathParam = profileOverride ?? _profile;
+    final ORSProfile chosenPathParam = profileOverride ?? _defaultProfile;
 
     // Build the request URL.
     final Uri uri = Uri.parse('$_matrixEndpointURL/${chosenPathParam.name}');

--- a/lib/src/services/optimization.dart
+++ b/lib/src/services/optimization.dart
@@ -2,8 +2,7 @@ part of 'package:open_route_service/src/open_route_service_base.dart';
 
 extension ORSOptimization on OpenRouteService {
   /// The endpoint of the openrouteservice Elevation API.
-  static const String _optimizationEndpointURL =
-      '${OpenRouteService._baseURL}/optimization';
+  String get _optimizationEndpointURL => '$_baseUrl/optimization';
 
   /// Get the Optimization Data from openrouteservice for Vehicle routing
   /// problem scheduling, for the input [jobs], [vehicles] and optionally

--- a/lib/src/services/pois.dart
+++ b/lib/src/services/pois.dart
@@ -2,7 +2,7 @@ part of 'package:open_route_service/src/open_route_service_base.dart';
 
 extension ORSPois on OpenRouteService {
   /// The endpoint of the openrouteservice Directions API.
-  static const String _poisEndpointURL = '${OpenRouteService._baseURL}/pois';
+  String get _poisEndpointURL => '$_baseUrl/pois';
 
   /// Fetches the information about the Points of Interest (POI) in the area
   /// surrounding a geometry which can either be a bounding box, polygon

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_route_service
 description: An encapsulation made around openrouteservice APIs, for Dart and Flutter projects, to easily generate Routes and their data. 
-version: 1.2.3
+version: 1.2.4
 repository: https://github.com/dhi13man/open_route_service/
 homepage: https://github.com/dhi13man/open_route_service/
 issue_tracker: https://github.com/Dhi13man/open_route_service/issues


### PR DESCRIPTION
1. **MINOR BREAKING:** Removed getter and setter for `profile` in `OpenRouteService` class. It is now final and can only be set via the constructor `defaultProfile` parameter. This system is more concurrency-safe. If it needs to be overridden at the API call level, that can anyway be done by passing in `profileOverride` to the respective API method.

2. #17 | Made API more flexible by allowing constructor-based overrides in `OpenRouteService` class of:
  - `baseUrl`, the default API Base URL
  - `client`, the HTTP Client being used to make the requests
  - `defaultProfile`, the default openrouteservice profile being used to make the requests.

3. [Ternary operator null check replaced with the null-aware operator in Vroom and Optimization data models](https://github.com/Dhi13man/open_route_service/pull/18/commits/5fcb31c1b01f7da1bd01dedffbbcb4098d588c05)

4. [Getting from name and vice versa is now done using a map internally, making it more readable and maintainable](https://github.com/Dhi13man/open_route_service/pull/18/commits/72f38f21b56c3bc95ba187744f99d5b13e537586)