### PR TITLE
Empty checks to prevent breaking when receiving empty openrouteservice collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Releases
 
-## [1.2.5] - 6th Feb, 2024
+## [1.2.6] - 6th April, 2024
+
+- Empty checks to prevent breaking when receiving empty collections from openrouteservice. Fixes [Issue #21](https://github.com/Dhi13man/open_route_service/issues/21).
+- Unit Tests for empty GeoJSON Feature serialisation/deserialisation added.
+
+## [1.2.5] - 29th March, 2024
 
 - Fixed broken compatibility with `geodart` GeoJSON serialisation/deserialisation as reported in [Issue #19](https://github.com/Dhi13man/open_route_service/issues/19).
 - Using `geojson` package as a dev dependency, for unit testing compatibility with GeoJSON.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_route_service
 description: An encapsulation made around openrouteservice APIs, for Dart and Flutter projects, to easily generate Routes and their data. 
-version: 1.2.5
+version: 1.2.6
 repository: https://github.com/dhi13man/open_route_service/
 homepage: https://github.com/dhi13man/open_route_service/
 issue_tracker: https://github.com/Dhi13man/open_route_service/issues

--- a/test/miscellaneous/geojson_tests.dart
+++ b/test/miscellaneous/geojson_tests.dart
@@ -3,7 +3,54 @@ import 'package:open_route_service/open_route_service.dart';
 import 'package:test/test.dart';
 
 void geoJsonTests() {
-  test('Test GeoJSON Coordinate Point serialization', () {
+  test('Test GeoJSON Feature Collection serialization', () {
+    // Arrange
+    final List<ORSCoordinate> coordinates = <ORSCoordinate>[
+      ORSCoordinate(latitude: 3.0, longitude: 0.0),
+      ORSCoordinate(latitude: 3.0, longitude: 0.0)
+    ];
+    final GeoJsonFeatureCollection feature = GeoJsonFeatureCollection(
+        bbox: coordinates, features: <GeoJsonFeature>[]);
+
+    // Act
+    final Map<String, dynamic> result = feature.toJson();
+
+    // Assert
+    expect(
+      result,
+      <String, dynamic>{
+        'type': 'FeatureCollection',
+        'bbox': <double>[0.0, 3.0, 0.0, 3.0],
+        'features': <Map<String, dynamic>>[]
+      },
+    );
+  });
+
+  test('Test GeoJSON Feature Collection deserialization', () {
+    // Arrange
+    final Map<String, dynamic> json = <String, dynamic>{
+      'type': 'FeatureCollection',
+      'bbox': <double>[0.0, 3.0, 0.0, 1.5],
+      'features': <Map<String, dynamic>>[]
+    };
+
+    // Act
+    final GeoJsonFeatureCollection result =
+        GeoJsonFeatureCollection.fromJson(json);
+
+    // Assert
+    final GeoJsonFeatureCollection expected = GeoJsonFeatureCollection(
+      bbox: <ORSCoordinate>[
+        ORSCoordinate(latitude: 3.0, longitude: 0.0),
+        ORSCoordinate(latitude: 1.5, longitude: 0.0)
+      ],
+      features: <GeoJsonFeature>[],
+    );
+    expect(result.bbox, expected.bbox);
+    expect(result.features, expected.features);
+  });
+
+  test('Test GeoJSON Point Coordinate serialization', () {
     // Arrange
     final List<ORSCoordinate> coordinates = <ORSCoordinate>[
       ORSCoordinate(latitude: 1.5, longitude: 0.0)
@@ -37,7 +84,7 @@ void geoJsonTests() {
     );
   });
 
-  test('Test GeoJSON Coordinate Point deserialization', () {
+  test('Test GeoJSON Point Coordinate deserialization', () {
     // Arrange
     final Map<String, dynamic> json = <String, dynamic>{
       'type': 'Feature',
@@ -85,7 +132,7 @@ void geoJsonTests() {
     }
   });
 
-  test('Test GeoJSON Coordinate Point serialization and deserialization', () {
+  test('Test GeoJSON Point Coordinate serialization and deserialization', () {
     // Arrange
     final Point original = Point(Coordinate(51.5, 0.0));
 
@@ -102,5 +149,77 @@ void geoJsonTests() {
     expect(result.bbox.minLat, original.bbox.minLat);
     expect(result.bbox.minLong, original.bbox.minLong);
     expect(result.properties, original.properties);
+  });
+
+  test('Test GeoJSON Empty Coordinates serialization', () {
+    // Arrange
+    final GeoJsonFeature feature = GeoJsonFeature(
+      type: 'Feature',
+      geometry: GeoJsonFeatureGeometry(
+        coordinates: <List<ORSCoordinate>>[],
+        type: 'Point',
+        internalType: GsonFeatureGeometryCoordinatesType.empty,
+      ),
+      properties: <String, dynamic>{},
+    );
+
+    // Act
+    final Map<String, dynamic> result = feature.toJson();
+
+    // Assert
+    expect(
+      result,
+      <String, dynamic>{
+        'type': 'Feature',
+        'geometry': <String, dynamic>{
+          'type': 'Point',
+          'coordinates': <List<double>>[]
+        },
+        'properties': <String, dynamic>{}
+      },
+    );
+  });
+
+  test('Test GeoJSON Empty Coordinate deserialization', () {
+    // Arrange
+    final Map<String, dynamic> json = <String, dynamic>{
+      'type': 'Feature',
+      'geometry': <String, dynamic>{
+        'type': 'Point',
+        'coordinates': <List<double>>[]
+      },
+      'properties': <String, dynamic>{}
+    };
+
+    // Act
+    final GeoJsonFeature result = GeoJsonFeature.fromJson(json);
+
+    // Assert
+    final GeoJsonFeature expected = GeoJsonFeature(
+      type: 'Feature',
+      geometry: GeoJsonFeatureGeometry(
+        coordinates: <List<ORSCoordinate>>[],
+        type: 'Point',
+        internalType: GsonFeatureGeometryCoordinatesType.empty,
+      ),
+      properties: <String, dynamic>{},
+    );
+    expect(result.bbox, expected.bbox);
+    expect(result.properties, expected.properties);
+    expect(result.type, expected.type);
+    expect(result.geometry.internalType, expected.geometry.internalType);
+    expect(result.geometry.type, expected.geometry.type);
+    for (int i = 0; i < result.geometry.coordinates.length; i++) {
+      for (int j = 0; j < result.geometry.coordinates[i].length; j++) {
+        expect(
+          result.geometry.coordinates[i][j].latitude,
+          expected.geometry.coordinates[i][j].latitude,
+        );
+        expect(
+          result.geometry.coordinates[i][j].longitude,
+          expected.geometry.coordinates[i][j].longitude,
+        );
+      }
+    }
   });
 }

--- a/test/miscellaneous/geojson_tests.dart
+++ b/test/miscellaneous/geojson_tests.dart
@@ -10,7 +10,9 @@ void geoJsonTests() {
       ORSCoordinate(latitude: 3.0, longitude: 0.0)
     ];
     final GeoJsonFeatureCollection feature = GeoJsonFeatureCollection(
-        bbox: coordinates, features: <GeoJsonFeature>[]);
+      bbox: coordinates,
+      features: <GeoJsonFeature>[],
+    );
 
     // Act
     final Map<String, dynamic> result = feature.toJson();
@@ -44,6 +46,48 @@ void geoJsonTests() {
         ORSCoordinate(latitude: 3.0, longitude: 0.0),
         ORSCoordinate(latitude: 1.5, longitude: 0.0)
       ],
+      features: <GeoJsonFeature>[],
+    );
+    expect(result.bbox, expected.bbox);
+    expect(result.features, expected.features);
+  });
+
+  test('Test empty GeoJSON Feature Collection serialization', () {
+    // Arrange
+    final GeoJsonFeatureCollection feature = GeoJsonFeatureCollection(
+      bbox: <ORSCoordinate>[],
+      features: <GeoJsonFeature>[],
+    );
+
+    // Act
+    final Map<String, dynamic> result = feature.toJson();
+
+    // Assert
+    expect(
+      result,
+      <String, dynamic>{
+        'type': 'FeatureCollection',
+        'bbox': <double>[],
+        'features': <Map<String, dynamic>>[],
+      },
+    );
+  });
+
+  test('Test empty GeoJSON Feature Collection deserialization', () {
+    // Arrange
+    final Map<String, dynamic> json = <String, dynamic>{
+      'type': 'FeatureCollection',
+      'bbox': <double>[],
+      'features': <Map<String, dynamic>>[],
+    };
+
+    // Act
+    final GeoJsonFeatureCollection result =
+        GeoJsonFeatureCollection.fromJson(json);
+
+    // Assert
+    final GeoJsonFeatureCollection expected = GeoJsonFeatureCollection(
+      bbox: <ORSCoordinate>[],
       features: <GeoJsonFeature>[],
     );
     expect(result.bbox, expected.bbox);
@@ -151,7 +195,7 @@ void geoJsonTests() {
     expect(result.properties, original.properties);
   });
 
-  test('Test GeoJSON Empty Coordinates serialization', () {
+  test('Test empty GeoJSON Coordinates serialization', () {
     // Arrange
     final GeoJsonFeature feature = GeoJsonFeature(
       type: 'Feature',
@@ -180,7 +224,7 @@ void geoJsonTests() {
     );
   });
 
-  test('Test GeoJSON Empty Coordinate deserialization', () {
+  test('Test empty GeoJSON Coordinate deserialization', () {
     // Arrange
     final Map<String, dynamic> json = <String, dynamic>{
       'type': 'Feature',


### PR DESCRIPTION
- Empty checks to prevent breaking when receiving empty collections from openrouteservice. Fixes [Issue #21](https://github.com/Dhi13man/open_route_service/issues/21).
- Unit Tests for empty GeoJSON Feature serialisation/deserialisation added.